### PR TITLE
fix(#207): モック時のhome/away判定不整合を解消

### DIFF
--- a/src/clients/llm_client.py
+++ b/src/clients/llm_client.py
@@ -219,6 +219,7 @@ class LLMClient:
         self,
         team_name: str,
         opponent_team: str,
+        is_home: bool,
         manager_name: str = None,
         opponent_manager_name: str = None,
     ) -> str:
@@ -228,43 +229,14 @@ class LLMClient:
         Args:
             team_name: 対象チーム名
             opponent_team: 対戦相手チーム名
+            is_home: 対象チームがホーム側かどうか
             manager_name: 監督名（省略時は「監督」を使用）
             opponent_manager_name: 対戦相手の監督名（省略時は「相手監督」を使用）
         """
         if self.use_mock:
             from src.mock_provider import MockProvider
-            # Determine if home or away based on team_name (simplified logic for now, assumes caller context)
-            # Actually summarize_interview arguments don't strictly say who is home/away easily without context
-            # But usually team_name is the target.
-            # Let's assume team_name is what we look for.
-            # To be safe, we might need a way to know if it's home or away.
-            # In news_service.py:
-            # team_name = match.core.home_team if is_home else match.core.away_team
-            # opponent_team = match.core.away_team if is_home else match.core.home_team
-            # So we can imply is_home by checking if team_name is home in the match context found in MockProvider?
-            # MockProvider.get_interview_summary takes (team, opponent, is_home).
-            # We can pass is_home=True temporarily and let MockProvider handle it or just pass names.
-            # Re-reading my MockProvider update:
-            # get_interview_summary(cls, team_name: str, opponent_team: str, is_home: bool)
-            # home = cls._normalize_team_name(team_name if is_home else opponent_team)
-            # If is_home=True, home=team_name. If is_home=False, home=opponent_team.
-            # This works. matching the logic in news_service.
 
-            # Use a heuristic or check MockProvider data?
-            # Simplest: Check matches in MockProvider?
-            # Or just pass is_home=True if we treat the first arg as "primary/home in this context"
-            # BUT wait, the file naming is home_away.json.
-            # We need to correctly identify which team is home in the fixture.
-            matches = MockProvider.get_matches()
-            is_fixture_home = False
-            for m in matches:
-                if m.core.home_team == team_name:
-                    is_fixture_home = True
-                    break
-
-            return MockProvider.get_interview_summary(
-                team_name, opponent_team, is_fixture_home
-            )
+            return MockProvider.get_interview_summary(team_name, opponent_team, is_home)
 
         # 監督名が指定されていない場合はデフォルト値
         manager_display = manager_name or "監督"
@@ -316,7 +288,11 @@ class LLMClient:
             return "エラーにつき取得不可（情報の取得に失敗しました）"
 
     def generate_transfer_news(
-        self, team_name: str, match_date: str, transfer_window_context: str = "latest"
+        self,
+        team_name: str,
+        match_date: str,
+        transfer_window_context: str = "latest",
+        is_home: bool = True,
     ) -> str:
         """
         移籍情報を生成（Grounding機能使用）
@@ -325,13 +301,12 @@ class LLMClient:
             team_name: チーム名
             match_date: 試合開催日 (YYYY-MM-DD)
             transfer_window_context: 検索用コンテキスト（デフォルト "latest"）
+            is_home: 対象チームがホーム側かどうか（モック時に使用）
         """
         if self.use_mock:
             from src.mock_provider import MockProvider
 
-            return MockProvider.get_transfer_news(
-                team_name, match_date, is_home=True
-            )  # is_home logic is inside get_transfer_news now
+            return MockProvider.get_transfer_news(team_name, match_date, is_home)
 
         prompt = build_prompt(
             "transfer_news",

--- a/src/news_service.py
+++ b/src/news_service.py
@@ -111,6 +111,7 @@ class NewsService:
             summary = self.llm.summarize_interview(
                 team_name,
                 opponent_team=opponent_team,
+                is_home=is_home,
                 manager_name=manager_name,
                 opponent_manager_name=opponent_manager_name,
             )
@@ -151,7 +152,10 @@ class NewsService:
         for is_home in [True, False]:
             team_name = match.core.home_team if is_home else match.core.away_team
             news = self.llm.generate_transfer_news(
-                team_name, match_date=match_date, transfer_window_context=context
+                team_name,
+                match_date=match_date,
+                transfer_window_context=context,
+                is_home=is_home,
             )
             news = self.filter.check_text(news)
 

--- a/tests/test_issue_207_mock_home_away.py
+++ b/tests/test_issue_207_mock_home_away.py
@@ -1,0 +1,117 @@
+import unittest
+from unittest.mock import MagicMock
+
+from src.clients.llm_client import LLMClient
+from src.domain.models import MatchAggregate, MatchCore
+from src.mock_provider import MockProvider
+from src.news_service import NewsService
+
+
+class TestIssue207MockHomeAway(unittest.TestCase):
+    def setUp(self):
+        self.mock_llm_client = LLMClient(use_mock=True)
+
+    def _create_match(self) -> MatchAggregate:
+        core = MatchCore(
+            id="fixture-207",
+            home_team="Manchester City",
+            away_team="Exeter City",
+            competition="FA Cup",
+            kickoff_jst="2026/01/10 12:00 JST",
+            kickoff_local="2026-01-10 20:00 Local",
+            match_date_local="2026-01-10",
+            is_target=True,
+        )
+        match = MatchAggregate(core=core)
+        match.facts.home_manager = "Pep Guardiola"
+        match.facts.away_manager = "Gary Caldwell"
+        return match
+
+    def test_llm_client_uses_home_away_key_for_interview_in_mock(self):
+        home_summary = self.mock_llm_client.summarize_interview(
+            "Manchester City",
+            opponent_team="Exeter City",
+            is_home=True,
+        )
+        away_summary = self.mock_llm_client.summarize_interview(
+            "Exeter City",
+            opponent_team="Manchester City",
+            is_home=False,
+        )
+
+        self.assertEqual(
+            home_summary,
+            MockProvider.get_interview_summary("Manchester City", "Exeter City", True),
+        )
+        self.assertEqual(
+            away_summary,
+            MockProvider.get_interview_summary("Exeter City", "Manchester City", False),
+        )
+        self.assertNotEqual(home_summary, away_summary)
+
+    def test_llm_client_uses_home_away_key_for_transfer_in_mock(self):
+        home_news = self.mock_llm_client.generate_transfer_news(
+            "Manchester City",
+            match_date="2026-01-10",
+            transfer_window_context="winter transfer window 2026",
+            is_home=True,
+        )
+        away_news = self.mock_llm_client.generate_transfer_news(
+            "Exeter City",
+            match_date="2026-01-10",
+            transfer_window_context="winter transfer window 2026",
+            is_home=False,
+        )
+
+        self.assertEqual(
+            home_news,
+            MockProvider.get_transfer_news("Manchester City", "2026-01-10", True),
+        )
+        self.assertEqual(
+            away_news,
+            MockProvider.get_transfer_news("Exeter City", "2026-01-10", False),
+        )
+        self.assertNotEqual(home_news, away_news)
+
+    def test_news_service_passes_is_home_to_summarize_interview(self):
+        mock_llm = MagicMock()
+        mock_llm.summarize_interview.side_effect = ["home interview", "away interview"]
+        service = NewsService(llm_client=mock_llm)
+        match = self._create_match()
+
+        service._process_interviews(match)
+
+        self.assertEqual(mock_llm.summarize_interview.call_count, 2)
+        first_call = mock_llm.summarize_interview.call_args_list[0]
+        second_call = mock_llm.summarize_interview.call_args_list[1]
+
+        self.assertEqual(first_call.args[0], "Manchester City")
+        self.assertEqual(first_call.kwargs["opponent_team"], "Exeter City")
+        self.assertTrue(first_call.kwargs["is_home"])
+        self.assertEqual(second_call.args[0], "Exeter City")
+        self.assertEqual(second_call.kwargs["opponent_team"], "Manchester City")
+        self.assertFalse(second_call.kwargs["is_home"])
+
+    def test_news_service_passes_is_home_to_transfer_news(self):
+        mock_llm = MagicMock()
+        mock_llm.generate_transfer_news.side_effect = [
+            "home transfer news",
+            "away transfer news",
+        ]
+        service = NewsService(llm_client=mock_llm)
+        match = self._create_match()
+
+        service._process_transfer_news(match)
+
+        self.assertEqual(mock_llm.generate_transfer_news.call_count, 2)
+        first_call = mock_llm.generate_transfer_news.call_args_list[0]
+        second_call = mock_llm.generate_transfer_news.call_args_list[1]
+
+        self.assertEqual(first_call.args[0], "Manchester City")
+        self.assertTrue(first_call.kwargs["is_home"])
+        self.assertEqual(second_call.args[0], "Exeter City")
+        self.assertFalse(second_call.kwargs["is_home"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/verify_llm_integration.py
+++ b/tests/verify_llm_integration.py
@@ -19,22 +19,17 @@ def verify_llm_integration():
     client = LLMClient(use_mock=False)
 
     team_name = "Manchester City"
-    # Groundingプロンプトでは articles は検索キーワードのヒントには使っていないが、
-    # 引数としては必要。
-    dummy_articles = [
-        {
-            "content": "Dummy content",
-            "title": "Dummy Title",
-            "source": "Dummy Source",
-            "url": "http://dummy.com",
-        }
-    ]
+    opponent_team = "Liverpool"
 
     print(f"\nCalling summarize_interview for {team_name}...")
     print("Expected behavior: Should call GeminiRestClient and perform Google Search.")
 
     try:
-        summary = client.summarize_interview(team_name, dummy_articles)
+        summary = client.summarize_interview(
+            team_name,
+            opponent_team=opponent_team,
+            is_home=True,
+        )
 
         print("\n" + "=" * 50)
         print("GENERATED SUMMARY")


### PR DESCRIPTION
## 概要
- LLMClient.summarize_interview に is_home 明示引数を追加
- LLMClient.generate_transfer_news に is_home を追加し、モック時の固定Trueを解消
- NewsService から interview/transfer 呼び出し時に is_home を明示的に渡す
- モック時のhome/away混同を防ぐ回帰テストを追加

## テスト
- python -m unittest tests/test_issue_207_mock_home_away.py tests/test_transfer_flag.py

Closes #207