### PR TITLE
refactor(#251): reduce CI log noise and fix redundant Firebase sync

### DIFF
--- a/src/clients/llm_client.py
+++ b/src/clients/llm_client.py
@@ -439,14 +439,19 @@ class LLMClient:
     def _log_llm_request(
         self, prompt_type: str, prompt: str, max_chars: int = 500, **params
     ):
-        """LLMリクエストをログ出力"""
+        """LLMリクエストをログ出力（GitHub Actions では折りたたみブロックで囲む）"""
         params_str = (
             ", ".join(f"{k}={v}" for k, v in params.items()) if params else "no params"
         )
+        in_actions = os.getenv("GITHUB_ACTIONS") == "true"
+        if in_actions:
+            print(f"::group::LLM Request [{prompt_type}] ({params_str})", flush=True)
         logger.info(f"=== LLM Request [{prompt_type}] ({params_str}) ===")
         display = prompt[:max_chars] + "..." if len(prompt) > max_chars else prompt
         logger.info(f"Prompt ({len(prompt)} chars): {display}")
         logger.info(f"=== End LLM Request [{prompt_type}] ===")
+        if in_actions:
+            print("::endgroup::", flush=True)
 
     def _log_llm_response(
         self,
@@ -455,9 +460,15 @@ class LLMClient:
         max_chars: int = 3000,
         source: str = "api",
     ):
-        """LLM応答をログ出力（長すぎる場合はtruncate）"""
+        """LLM応答をログ出力（長すぎる場合はtruncate、GitHub Actions では折りたたみブロックで囲む）"""
         if not response:
             return
+        in_actions = os.getenv("GITHUB_ACTIONS") == "true"
+        if in_actions:
+            print(
+                f"::group::LLM Response [{prompt_type}] (source={source}, {len(response)} chars)",
+                flush=True,
+            )
         display = (
             response[:max_chars] + "..." if len(response) > max_chars else response
         )
@@ -466,6 +477,8 @@ class LLMClient:
         )
         logger.info(display)
         logger.info(f"=== End LLM Response [{prompt_type}] ===")
+        if in_actions:
+            print("::endgroup::", flush=True)
 
     # ========== モック用メソッド ==========
 

--- a/src/html_generator.py
+++ b/src/html_generator.py
@@ -75,30 +75,8 @@ def generate_html_report(content: str, report_datetime: str = None) -> str:
         extensions=["tables", "fenced_code", "nl2br", "markdown.extensions.md_in_html"],
     )
 
-    # CSS外部参照HTMLテンプレート
-    html_template = f"""<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{mode_prefix}サッカー観戦ガイド - {report_date}</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{CSS_PATH}">
-</head>
-<body>
-    <div class="container">
-        <a href="../index.html" class="back-link">← レポート一覧に戻る</a>
-        {mode_banner}
-        {html_body}
-        <div class="timestamp">
-            生成日時: {timestamp}
-        </div>
-    </div>
-</body>
-</html>
-"""
+    title = f"{mode_prefix}サッカー観戦ガイド - {report_date}"
+    html_template = _get_html_template(title, html_body, timestamp, mode_banner)
 
     # 出力ディレクトリ作成
     Path(REPORTS_DIR).mkdir(parents=True, exist_ok=True)
@@ -136,16 +114,7 @@ def generate_html_reports(report_list: list) -> list:
         生成されたHTMLファイルパスのリスト
     """
     now_jst = DateTimeUtil.now_jst()
-    DateTimeUtil.format_display_timestamp(now_jst)
     generation_datetime = DateTimeUtil.format_filename_datetime(now_jst)
-
-    # デバッグ/モックモード判定
-    if config.USE_MOCK_DATA:
-        pass
-    elif config.DEBUG_MODE:
-        pass
-    else:
-        pass
 
     # 出力ディレクトリ作成
     Path(REPORTS_DIR).mkdir(parents=True, exist_ok=True)

--- a/src/workflows/generate_guide_workflow.py
+++ b/src/workflows/generate_guide_workflow.py
@@ -300,12 +300,7 @@ class GenerateGuideWorkflow:
     def _generate_html(self, report_list):
         html_paths = []
         try:
-            from src.html_generator import generate_html_reports, sync_from_firebase
-
-            if not config.USE_MOCK_DATA:
-                sync_from_firebase()
-            else:
-                logger.info("Mock mode: Skipping Firebase sync")
+            from src.html_generator import generate_html_reports
 
             html_paths = generate_html_reports(report_list)
             logger.info(f"Generated {len(html_paths)} HTML files")


### PR DESCRIPTION
## Summary

- **LLMログの折りたたみ**: GitHub Actions 環境で `_log_llm_request()` / `_log_llm_response()` のログ本文を `::group::` / `::endgroup::` で囲み、プロンプト/レスポンス全文が Actions ログで折りたたみ表示されるようになった
- **GCS バックアップ肥大化の解消**: `_generate_html()` 内の `sync_from_firebase()` 呼び出しを削除。これにより CI の backup step (`gsutil rsync`) で過去の全レポートが毎回コピーされる問題が解消され、新規生成分のみバックアップされる
- **dead code 削除**: `html_generator.py` の未使用変数代入・no-op if/elif/else ブロック・インライン HTML テンプレート（既存の `_get_html_template()` で代替）を削除

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/clients/llm_client.py` | `_log_llm_request/response` に Actions グループ化を追加 |
| `src/workflows/generate_guide_workflow.py` | `sync_from_firebase()` 呼び出し削除 |
| `src/html_generator.py` | dead code 3箇所削除、`_get_html_template()` 活用 |

## Test plan

- [x] `python -m unittest discover tests` — 124 tests passed (1 pre-existing import error unrelated to this PR)
- [ ] CI 実行後に LLM ログが折りたたみブロックとして表示されることを確認
- [ ] 次回 CI 実行で GCS backup step のコピー件数が新規レポート数のみになることを確認

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)