### PR TITLE
Add WCQ support and Athletic player profiles

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,10 @@
         ]
       }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(python main.py*)"
+    ]
   }
 }

--- a/config.py
+++ b/config.py
@@ -63,7 +63,7 @@ class Config:
                 )
         except Exception as e:
             # Fallback to hardcoded defaults if YAML loading fails
-            self.TARGET_LEAGUES = ["EPL", "CL", "LALIGA", "FA", "COPA", "EFL"]
+            self.TARGET_LEAGUES = ["EPL", "CL", "LALIGA", "FA", "COPA", "EFL", "WCQ"]
             self.LEAGUE_IDS = {
                 "EPL": 39,
                 "CL": 2,
@@ -71,6 +71,7 @@ class Config:
                 "FA": 45,
                 "COPA": 143,
                 "EFL": 48,
+                "WCQ": 32,
             }
             self.LEAGUE_INFO = []
             print(

--- a/public/player-profiles/128398.html
+++ b/public/player-profiles/128398.html
@@ -1,0 +1,32 @@
+<section class="player-profile-section">
+    <h4>基本情報</h4>
+    <p>生まれ：2000年4月25日、スペイン・パンプローナ。OsasunaのTajonarから2015年にAthletic Clubへ移り、Lezamaで大型トップ下として育った。<br>国籍：スペイン<br>ポジション：攻撃的MF / セカンドトップ<br>身長・利き足：188cm / 右利き</p>
+</section>
+<section class="player-profile-section">
+    <h4>経歴</h4>
+    <p>2015-2018: Athletic Club（Osasunaの育成組織から加入）<br>2018-2020: Bilbao Athletic<br>2020-: Athletic Club</p>
+</section>
+<section class="player-profile-section">
+    <h4>代表歴</h4>
+    <p>スペイン代表。2023年にA代表デビューを果たし、得点も記録している。</p>
+</section>
+<section class="player-profile-section">
+    <h4>特徴</h4>
+    <p>188cmのサイズがありながら、ただの大型MFではなく、ライン間で半身になって受ける感覚と、ゴール前へ入っていくタイミングが鋭い。AthleticではWilliams兄弟の外の速さとGuruzetaのポストプレーを、中央で得点に変える“二列目の9番”に近い役割を担う。</p>
+</section>
+<section class="player-profile-section">
+    <h4>監督・選手の発言</h4>
+    <p>2032年までの長期契約について、本人はクラブからの信頼を返す責任があるという趣旨で語っている。才能を売るための契約ではなく、全盛期をSan Mamésに置くという意思表示に見える点がAthleticらしい。</p>
+</section>
+<section class="player-profile-section">
+    <h4>記録</h4>
+    <p>2022年1月、古巣Osasunaの本拠地El Sadarでハットトリックを決め、1-3の逆転勝利を導いた。2023年4月には2032年までの8年契約を結び、当時のAthleticでも異例の長期コミットメントとして話題になった。</p>
+</section>
+<section class="player-profile-section">
+    <h4>面白いエピソード</h4>
+    <p>契約延長発表は普通のリリースだけでなく、Getafe戦後のSan Mamésのピッチ上で本人がマイクを持ってファンに伝える演出だった。観客が帰る前に大型ビジョンと場内アナウンスで引き止められ、本人が「更新した」と告げる、ほとんど公開プロポーズのような場面になった。</p>
+</section>
+<section class="player-profile-section">
+    <h4>意外な経歴</h4>
+    <p>Osasunaの育成で目を引いた少年をAthleticがcadete年代で引き抜いた経緯があり、Navarraの才能をめぐる両クラブの微妙な関係も背負っている。だからこそEl Sadarでのハットトリックは、単なる3得点ではなく、育成ルートそのものに物語が乗った試合だった。</p>
+</section>

--- a/public/player-profiles/183799.html
+++ b/public/player-profiles/183799.html
@@ -1,0 +1,28 @@
+<section class="player-profile-section">
+    <h4>基本情報</h4>
+    <p>生まれ：2002年7月12日、スペイン・パンプローナ。兄Iñakiと同じガーナ系の家庭に生まれ、11歳でAthletic ClubのLezamaへ入った。<br>国籍：スペイン（ガーナ系）<br>ポジション：左ウィンガー / 右ウィンガー<br>身長・利き足：181cm / 右利き</p>
+</section>
+<section class="player-profile-section">
+    <h4>経歴</h4>
+    <p>2013-2020: Athletic Club（Lezama）<br>2020-2021: Bilbao Athletic<br>2021-: Athletic Club</p>
+</section>
+<section class="player-profile-section">
+    <h4>特徴</h4>
+    <p>縦突破の速さだけでなく、相手SBを外へ引っ張った後に内側へ入って組み直せるのが強み。UEFAのEURO 2024決勝分析では、前半のスペインがライン間へ通したパスの受け手として左サイドのNicoとCucurellaが重要だったと整理されており、単なるドリブラーではなく構造を進める出口になっていた。</p>
+</section>
+<section class="player-profile-section">
+    <h4>監督・選手の発言</h4>
+    <p>EURO 2024決勝のPlayer of the Match選出時、UEFA技術監視員は、攻撃で危険だっただけでなく、Cucurellaを助ける守備やDani Olmoとの中盤連係も評価した。本人も決勝後、あのゴールをキャリアで最も重要な瞬間の一つとして語っている。</p>
+</section>
+<section class="player-profile-section">
+    <h4>記録</h4>
+    <p>UEFA EURO 2024決勝のEngland戦でLamine Yamalのパスから先制点を決め、Player of the Matchに選出された。2024年のBallon d&#39;Orでは15位、2024-25シーズンにはUEFA Europa League Team of the Seasonにも選ばれ、クラブ外からの視線を一気に集める選手になった。</p>
+</section>
+<section class="player-profile-section">
+    <h4>面白いエピソード</h4>
+    <p>両親はガーナからサハラ砂漠を越えてスペインへ渡った背景を持つ。Nicoは兄Iñakiと同じクラブでプレーしながらスペイン代表を選び、兄はガーナ代表を選んだため、家族のルーツと育った国がピッチ上で二重に表れる稀な兄弟になっている。</p>
+</section>
+<section class="player-profile-section">
+    <h4>意外な経歴</h4>
+    <p>父はスペイン移住後にStamford Bridgeで電気技師として働いた時期があると紹介されている。Nicoがイングランド相手のEURO決勝で主役になったことを思うと、家族史の中にあるロンドンの労働現場とベルリンの決勝ゴールが、妙に遠くでつながって見える。</p>
+</section>

--- a/public/player-profiles/332308.html
+++ b/public/player-profiles/332308.html
@@ -1,0 +1,28 @@
+<section class="player-profile-section">
+    <h4>基本情報</h4>
+    <p>生まれ：2003年5月25日、スペイン・ベルメオ。Danok Batを経てAthletic Clubの育成組織へ入り、Basconia、Bilbao Athleticからトップチームへ上がった。<br>国籍：スペイン<br>ポジション：攻撃的MF / セントラルMF<br>身長・利き足：183cm / 右利き</p>
+</section>
+<section class="player-profile-section">
+    <h4>経歴</h4>
+    <p>Danok Batを経てAthletic Clubの育成へ<br>2021-2022: Basconia<br>2022-2023: Bilbao Athletic<br>2023-: Athletic Club</p>
+</section>
+<section class="player-profile-section">
+    <h4>特徴</h4>
+    <p>Athletic公式が「守備と攻撃の両局面での強度とテンポが100% Athleticのプロフィールに合う」と表現したMF。トップ下でもインサイドでも、ボールを受けてからの美しさより、走力・二度追い・こぼれ球への反応で試合に熱を入れる。</p>
+</section>
+<section class="player-profile-section">
+    <h4>監督・選手の発言</h4>
+    <p>2023年10月に2028年まで契約延長した際、クラブは彼を“intensity and tempo”の選手として紹介した。若手にありがちな技巧派扱いではなく、Athleticが大事にする労働量と攻守の切り替えで評価された点が面白い。</p>
+</section>
+<section class="player-profile-section">
+    <h4>記録</h4>
+    <p>2023年8月12日にSan MamésでReal Madrid相手にLaLigaデビューし、同月27日のReal Betis戦でプロ初ゴールを決めた。0-2からひっくり返した試合の締めの4点目で、デビュー直後の若手が一気にSan Mamésの記憶へ入った。</p>
+</section>
+<section class="player-profile-section">
+    <h4>面白いエピソード</h4>
+    <p>初ゴール後、Unai Gómezは涙を見せながら喜んだと現地メディアに伝えられた。Athleticでは“地元の若手がSan Mamésで泣く”という光景そのものが物語になり、数字以上にファンの感情へ刺さる。</p>
+</section>
+<section class="player-profile-section">
+    <h4>意外な経歴</h4>
+    <p>同じベルメオ出身のMikel Jauregizarとは、Lezama以前から近い世代の文脈で語られることがある。Athleticの中盤に、同じ港町から来た2003年生まれ前後の選手が複数入り込んでいるのは、クラブの地域密度を感じさせる小さな見どころ。</p>
+</section>

--- a/public/player-profiles/383780.html
+++ b/public/player-profiles/383780.html
@@ -1,0 +1,28 @@
+<section class="player-profile-section">
+    <h4>基本情報</h4>
+    <p>生まれ：2003年11月13日、スペイン・ベルメオ。ビスカヤの港町からBermeo FT、Lezama、Basconia、Bilbao Athleticを順に上がってきた。<br>国籍：スペイン<br>ポジション：セントラルMF / 守備的MF<br>身長・利き足：177cm / 右利き</p>
+</section>
+<section class="player-profile-section">
+    <h4>経歴</h4>
+    <p>2019-2021: Bermeo FT<br>2021-2022: Athletic Club（Lezama）<br>2022-2023: Basconia<br>2023-2024: Bilbao Athletic<br>2023-: Athletic Club</p>
+</section>
+<section class="player-profile-section">
+    <h4>特徴</h4>
+    <p>ボール奪取と前進を同じ呼吸で行う、いかにも現代的なAthleticの中盤。広い範囲を走って潰すだけでなく、相手陣内で奪った直後に縦へ出す判断が速く、2024-25シーズンは前線からの回収数でPedriに次ぐ水準だったと現地で紹介された。</p>
+</section>
+<section class="player-profile-section">
+    <h4>監督・選手の発言</h4>
+    <p>Athletic公式は契約延長時、Valverdeが2024-25シーズンに彼へ大きな役割を与えたことを強調した。本人は更新時に、San Mamésへ入る時に感じるものは他では感じられないという趣旨で語っており、若手の野心より“ここでキャリアを作る”姿勢が前に出ている。</p>
+</section>
+<section class="player-profile-section">
+    <h4>記録</h4>
+    <p>トップチーム初の本格シーズンとなった2024-25シーズンに公式戦48試合へ出場し、Europa League準決勝まで到達したチームの中盤を支えた。Old TraffordでのManchester United戦では、こぼれ球を拾って右足でゴール右上へ突き刺すミドルを決め、敗退濃厚の空気の中でもAthleticに夢を見せた。</p>
+</section>
+<section class="player-profile-section">
+    <h4>面白いエピソード</h4>
+    <p>背番号18は、過去30年でBittor Alkiza、Carlos Gurpegui、Oscar de Marcosらが背負ってきた番号として紹介される。Jauregizarがその番号を受け継いだことは、ただの若手抜擢ではなく、働き者でクラブ色の濃い中盤を次世代へ渡すサインとして読める。</p>
+</section>
+<section class="player-profile-section">
+    <h4>意外な経歴</h4>
+    <p>2021年にBermeo FTからLezamaへ来た時、本人は母がAthleticから声がかかったと聞いて冗談だと思ったと振り返っている。数年後には2031年まで、しかも解除条項なしの契約を結び、クラブ側が“売る前提”ではなく“中核にする前提”で囲った選手になった。</p>
+</section>

--- a/public/player-profiles/47270.html
+++ b/public/player-profiles/47270.html
@@ -1,0 +1,28 @@
+<section class="player-profile-section">
+    <h4>基本情報</h4>
+    <p>生まれ：1997年6月11日、スペイン・ビトリア＝ガステイス。アラバ県Murgiaで育ち、Aurrera VitoriaからAthletic ClubのLezamaへ入った。<br>国籍：スペイン<br>ポジション：ゴールキーパー<br>身長・利き足：190cm / 右利き</p>
+</section>
+<section class="player-profile-section">
+    <h4>経歴</h4>
+    <p>2011-2014: Athletic Club（Aurrera VitoriaからLezamaへ）<br>2014-2016: Basconia<br>2016-2018: Bilbao Athletic<br>2018-: Athletic Club</p>
+</section>
+<section class="player-profile-section">
+    <h4>特徴</h4>
+    <p>大柄なGKだが、売りは派手な横っ飛びだけではない。ゴール前に残る判断、低いクロスへの身体の出し方、ビルドアップで無理に目立ちすぎない配球の選択がうまく、Athleticでもスペイン代表でも「後ろが落ち着く」タイプの守護神になっている。</p>
+</section>
+<section class="player-profile-section">
+    <h4>監督・選手の発言</h4>
+    <p>2024年のZamora Trophy授賞式では、クラブの伝説Jose Angel Iribar本人からトロフィーを受け取った。SimónはIribarを幼いころからそばで見てきた存在として語りつつ、自分を同列に置く見方には慎重で、レジェンド継承の物語を謙虚に受け止めている。</p>
+</section>
+<section class="player-profile-section">
+    <h4>記録</h4>
+    <p>2023-24シーズンにLaLiga最少失点GKへ贈られるZamora Trophyを獲得し、AthleticのGKとしてはIribar以来54年ぶりの受賞になった。UEFA EURO 2024ではスペイン代表の優勝メンバーとして主力を務め、クラブと代表の両方で一気に履歴書を厚くした。</p>
+</section>
+<section class="player-profile-section">
+    <h4>面白いエピソード</h4>
+    <p>EURO 2020ではクロアチア戦でPedriの長いバックパスを処理できず、約45m級のオウンゴールという悪夢の場面を経験した。ところが次のスイス戦ではPK戦で2本を止め、スペインを準決勝へ連れていく側に回ったため、「ミスで壊れないGK」という印象を強く残した。</p>
+</section>
+<section class="player-profile-section">
+    <h4>意外な経歴</h4>
+    <p>父はGuardia Civil、母はErtzaintzaという警察関係の家庭に生まれたと紹介されることが多い。AthleticのGKは地域の象徴性を背負いやすいポジションだが、Simónは“地元の少年が伝説の後ろ姿を追った”というより、アラバからLezamaへ渡って自分の居場所を作った選手でもある。</p>
+</section>

--- a/public/player-profiles/47271.html
+++ b/public/player-profiles/47271.html
@@ -1,0 +1,28 @@
+<section class="player-profile-section">
+    <h4>基本情報</h4>
+    <p>生まれ：1995年1月24日、スペイン・バラカルド。Santutxuを経て2010年にAthletic Clubの育成組織へ入り、Lezamaで守備者として育った。<br>国籍：スペイン<br>ポジション：センターバック<br>身長・利き足：183cm / 右利き</p>
+</section>
+<section class="player-profile-section">
+    <h4>経歴</h4>
+    <p>2010-2014: Athletic Club（ユース）<br>2014-2016: Basconia<br>2015-2016: Bilbao Athletic<br>2016-: Athletic Club</p>
+</section>
+<section class="player-profile-section">
+    <h4>特徴</h4>
+    <p>派手なロングフィードより、相手FWとの距離管理、カバーリング、空中戦の粘りで守備ラインを落ち着かせるタイプ。AthleticのCBらしく前に潰しに出る勇気もあるが、真価は試合が荒れた時に不用意に飛び込まず、最後の一歩を残せる冷静さにある。</p>
+</section>
+<section class="player-profile-section">
+    <h4>監督・選手の発言</h4>
+    <p>2017年に精巣がんから復帰した際、当時の監督Cuco Zigandaは彼の復帰そのものを試合の物語として扱った。本人も復帰後に「人生で最も幸せな時期」と語ったと報じられ、単なる若手CBではなく、チーム全体が背中を押す存在になった。</p>
+</section>
+<section class="player-profile-section">
+    <h4>記録</h4>
+    <p>2016年にトップチームへ定着した直後に精巣がんが判明し、手術後に一度復帰したが、2017年に再発で化学療法を受けた。2025年にはがん治療後の脱毛対策薬に由来する禁止物質でUEFAから10か月の処分を受けたが、UEFAは意図的な違反ではない説明を認めている。</p>
+</section>
+<section class="player-profile-section">
+    <h4>面白いエピソード</h4>
+    <p>2017年、再発と治療が発表された時には、Athleticのチームメイトたちが彼を支えるために頭を丸めた。Lezama育ちのCB一人の病気が、クラブのロッカールーム全体を動かした出来事として記憶されている。</p>
+</section>
+<section class="player-profile-section">
+    <h4>意外な経歴</h4>
+    <p>2018年2月4日の復帰戦は、最初の復帰戦からちょうど1年後で、しかもWorld Cancer Dayだった。キャリアの節目が偶然にも病気との物語と重なり続けており、彼のプロフィールは成績表だけでは絶対に伝わらない重さを持っている。</p>
+</section>

--- a/public/player-profiles/47273.html
+++ b/public/player-profiles/47273.html
@@ -1,0 +1,28 @@
+<section class="player-profile-section">
+    <h4>基本情報</h4>
+    <p>生まれ：1990年2月10日、スペイン・サラウツ。Real Sociedadの育成からAthleticのユース、Tottenhamの下部組織、Real Sociedad復帰、PSGを経てAthletic Clubへたどり着いた。<br>国籍：スペイン<br>ポジション：左サイドバック<br>身長・利き足：181cm / 左利き</p>
+</section>
+<section class="player-profile-section">
+    <h4>経歴</h4>
+    <p>Real Sociedadの育成を離れ、Athletic Clubのユースを経て2007年にTottenhamへ移籍<br>2009-2012: Real Valladolid、Real Uniónへのローンを含むTottenham期<br>2012-2017: Real Sociedad<br>2017-2018: Paris Saint-Germain<br>2018-: Athletic Club</p>
+</section>
+<section class="player-profile-section">
+    <h4>移籍金</h4>
+    <p>2017年にReal SociedadからPSGへ移籍し、2018年にPSGからAthletic Clubへ加入。Athletic移籍時は初期費用1900万ユーロ、条件達成で最大2500万ユーロ規模と報じられた。</p>
+</section>
+<section class="player-profile-section">
+    <h4>特徴</h4>
+    <p>左足の推進力と球際の強さで、サイドバックというより“左のレーンを押し上げるエンジン”として機能する。若い頃は粗さも目立ったが、AthleticではNico Williamsの外側を走るだけでなく、セットプレーや逆サイドからのこぼれ球に入っていく得点感覚も見せる。</p>
+</section>
+<section class="player-profile-section">
+    <h4>記録</h4>
+    <p>PSGではLigue 1、Coupe de France、Coupe de la Ligueを経験し、その後Athleticで2023-24 Copa del Rey優勝メンバーになった。2024年2月のMallorca戦では左SBながらセットプレー絡みで2得点し、同じ相手とのCopa決勝へ向かう流れを強く印象づけた。</p>
+</section>
+<section class="player-profile-section">
+    <h4>面白いエピソード</h4>
+    <p>2024年Copa del Rey決勝前、YuriはAthleticでCopaを取れるなら他のタイトル全部と交換してもいいという趣旨の発言をした。PSGでタイトルを知った選手が、最終的に最も欲しがったのはSan Mamésの人々と共有する40年ぶりのCopaだった。</p>
+</section>
+<section class="player-profile-section">
+    <h4>意外な経歴</h4>
+    <p>Real Sociedad育ちでありながらAthleticのユースにも在籍し、さらにTottenhamとPSGを経由した、バスク文脈としてはかなり珍しい横断型キャリア。母がバスク系、父がアルジェリア系という背景もあり、Athleticの“地元性”を単純な出生地だけで語れないことを体現している。</p>
+</section>

--- a/public/player-profiles/47291.html
+++ b/public/player-profiles/47291.html
@@ -1,0 +1,28 @@
+<section class="player-profile-section">
+    <h4>基本情報</h4>
+    <p>生まれ：1996年9月12日、スペイン・サン・セバスティアン。AntiguokoからAthletic Clubの育成組織へ入り、一度クラブを離れてから戻ってきた遅咲きの9番。<br>国籍：スペイン<br>ポジション：センターフォワード<br>身長・利き足：188cm / 右利き</p>
+</section>
+<section class="player-profile-section">
+    <h4>経歴</h4>
+    <p>Antiguokoを経てAthletic Clubの育成へ<br>2015-2018: Basconia / Bilbao Athletic<br>2018-2020: Athletic Club<br>2020-2022: Sabadell、Amorebieta<br>2022-: Athletic Club</p>
+</section>
+<section class="player-profile-section">
+    <h4>特徴</h4>
+    <p>圧倒的なスピードや派手な個人技で勝つFWではなく、CBの間でボールを受け、周囲のWilliams兄弟やSancetを生かす“接着剤型”の9番。ワンタッチの落とし、ニアへの入り方、相手CBを背負ったまま時間を作る動きがうまく、得点数以上に攻撃の形を整える。</p>
+</section>
+<section class="player-profile-section">
+    <h4>監督・選手の発言</h4>
+    <p>Athletic公式は、復帰後すでに40得点以上を決めている点を紹介している。Guruzeta本人は欧州の試合後にも、個人の得点よりチームが最後まで生き残ることを強調する発言が多く、9番でありながら自己主張が前に出すぎない。</p>
+</section>
+<section class="player-profile-section">
+    <h4>記録</h4>
+    <p>2022年にAmorebietaからAthleticへ戻った後、LaLigaで一気に定着した。2023-24 Copa del Rey準決勝のAtletico Madrid戦では得点し、40年ぶりのCopa制覇へ向かうチームの前線で重要な役割を担った。</p>
+</section>
+<section class="player-profile-section">
+    <h4>面白いエピソード</h4>
+    <p>父Xabier GuruzetaはReal Sociedadでプレーした元DFで、Gorka自身もサン・セバスティアン生まれ。Real Sociedad色の強い出自を持つストライカーがAthleticの9番としてSan Mamésで愛される構図は、バスクサッカーの近さとライバル関係のややこしさをよく表している。</p>
+</section>
+<section class="player-profile-section">
+    <h4>意外な経歴</h4>
+    <p>一度Athleticを離れ、SabadellとAmorebietaを経て戻ってきたため、典型的なエリート街道の成功者ではない。むしろ外で泥臭く試合数を重ねてから帰還し、Valverdeのチームで主力化した“やり直しの成功例”として味わい深い。</p>
+</section>

--- a/public/player-profiles/47294.html
+++ b/public/player-profiles/47294.html
@@ -1,0 +1,28 @@
+<section class="player-profile-section">
+    <h4>基本情報</h4>
+    <p>生まれ：1994年6月15日、スペイン・ビルバオ。ガーナ出身の両親のもとに生まれ、幼少期の多くをパンプローナのRochapea地区で過ごした。<br>国籍：ガーナ（スペイン出身）<br>ポジション：右ウィンガー / センターフォワード<br>身長・利き足：186cm / 右利き</p>
+</section>
+<section class="player-profile-section">
+    <h4>経歴</h4>
+    <p>Club Natacion Pamplona、CD Pamplonaを経てAthletic Clubの育成組織へ<br>2014-2015: Bilbao Athletic<br>2014-: Athletic Club</p>
+</section>
+<section class="player-profile-section">
+    <h4>代表歴</h4>
+    <p>スペインの年代別代表とA代表1試合を経て、2022年に両親のルーツであるガーナ代表を選択した。弟Nico Williamsはスペイン代表を選んでおり、兄弟で同じクラブの両翼を担いながら代表では別々の国を背負う珍しい物語を持つ。</p>
+</section>
+<section class="player-profile-section">
+    <h4>特徴</h4>
+    <p>最大の武器は、背後へのランを何度でも繰り返せるスプリント能力と稼働率。中央で相手CBを押し下げるCFにも、右サイドから縦へ走ってクロスや折り返しを狙うWGにもなれるため、Athleticの攻撃に“奥行き”を作る役割を長く担っている。</p>
+</section>
+<section class="player-profile-section">
+    <h4>記録</h4>
+    <p>2016年4月20日から2023年1月22日までLaLigaで251試合連続出場し、ギネスにも認定されるリーグ記録を作った。2015年のEuropa League、Torino戦ではクラブ史上初の黒人選手による公式戦ゴールを決め、Athleticの歴史そのものを少し押し広げた選手でもある。</p>
+</section>
+<section class="player-profile-section">
+    <h4>面白いエピソード</h4>
+    <p>両親はガーナからサハラ砂漠を越え、Melillaのフェンスを越えてスペインへたどり着いたと伝えられている。Iñakiという名前は、家族をBilbaoへつなげた支援者に由来するとされ、彼のキャリアは単なるアカデミー成功談ではなく、移民家族がバスクの象徴的クラブの中心へ入っていく物語でもある。</p>
+</section>
+<section class="player-profile-section">
+    <h4>意外な経歴</h4>
+    <p>Athleticの育成に入ったのは幼少期からではなく、CD Pamplonaで目立ってからだった。Lezamaの“純粋培養”というより、Navarraの街クラブで速さを磨き、後からAthleticの哲学に合流してクラブの顔になったタイプで、そこが彼の立ち位置をより面白くしている。</p>
+</section>

--- a/public/player-profiles/622.html
+++ b/public/player-profiles/622.html
@@ -1,0 +1,32 @@
+<section class="player-profile-section">
+    <h4>基本情報</h4>
+    <p>生まれ：1994年5月27日、フランス・アジャン。フランス南西部出身で、Aviron Bayonnaisを経てAthletic Clubの育成網に入った。<br>国籍：スペイン（フランス出身）<br>ポジション：センターバック<br>身長・利き足：191cm / 左利き</p>
+</section>
+<section class="player-profile-section">
+    <h4>経歴</h4>
+    <p>2000-2009: SU Agen<br>2009-2010: Aviron Bayonnais<br>2010-2018: Athletic Club（ユース、Basconia、Bilbao Athletic、トップチーム）<br>2018-2023: Manchester City<br>2023-2025: Al-Nassr<br>2025-: Athletic Club</p>
+</section>
+<section class="player-profile-section">
+    <h4>移籍金</h4>
+    <p>2018年にAthletic ClubからManchester Cityへ移籍した際は、当時の両クラブにとって記録級となる約5700万ポンド規模の取引だった。2023年にAl-Nassrへ移り、2025年には約1000万ユーロ規模でAthletic Clubへ復帰した。</p>
+</section>
+<section class="player-profile-section">
+    <h4>特徴</h4>
+    <p>左利きCBとして、相手のプレスを横へ逃がすだけでなく、縦パスと対角フィードで一気に前進できるのが最大の価値。GuardiolaはCity時代に左足の質が攻撃のスピードを変えると評価しており、守備者というよりビルドアップの角度を増やす装置として重宝された。</p>
+</section>
+<section class="player-profile-section">
+    <h4>監督・選手の発言</h4>
+    <p>Guardiolaは負傷明けの2020年、Laporteを世界最高級の左利きセンターバックとして扱う発言をしている。単に守れるCBではなく、Cityの“後ろから試合を作る”構造において、左足でライン間へ刺せる希少性を持っていた。</p>
+</section>
+<section class="player-profile-section">
+    <h4>記録</h4>
+    <p>Manchester CityではPremier League複数回制覇、国内カップ、2022-23シーズンのChampions League優勝を含むトレブルを経験した。Athleticではフランス出身ながら育成年代を通じてトップにたどり着いた珍しいケースで、クラブの選手獲得哲学を語る時に必ず名前が出る存在になった。</p>
+</section>
+<section class="player-profile-section">
+    <h4>面白いエピソード</h4>
+    <p>LaporteのAthletic入りは、いわゆる“Basque-only”哲学の境界線をめぐって議論を呼んだ。彼はフランス領バスクのAviron Bayonnaisを経由して育成資格を満たしたため、Lizarazuとはまた違う形で、Athleticがどこまでを「自分たちの選手」と見るかを可視化した。</p>
+</section>
+<section class="player-profile-section">
+    <h4>意外な経歴</h4>
+    <p>2025年の復帰は、Al-Nassr側の国際移籍証明書まわりの手続き遅れで一度は登録が止まる異例の騒動になった。最終的に承認されて帰還したため、単なるベテラン補強ではなく、“哲学の境界線を通って出て行った選手が、書類ドラマまで経て戻ってきた”というかなりAthleticらしい物語になっている。</p>
+</section>

--- a/settings/leagues.yaml
+++ b/settings/leagues.yaml
@@ -29,3 +29,8 @@ leagues:
     id: 48
     display_name: EFL Cup
     logo_url: https://media.api-sports.io/football/leagues/48.png
+
+  - name: WCQ
+    id: 32
+    display_name: World Cup Qualification - Europe
+    logo_url: https://media.api-sports.io/football/leagues/32.png

--- a/src/domain/match_selector.py
+++ b/src/domain/match_selector.py
@@ -23,14 +23,15 @@ class MatchSelector:
         # Sort logic
         def sort_key(m: MatchAggregate):
             r_score = rank_order.get(m.rank, 99)
-            # Competition priority: CL > LALIGA > EPL > COPA > FA > EFL
+            # Competition priority: CL > WCQ > LALIGA > EPL > COPA > FA > EFL
             comp_priority = {
                 "CL": 0,
-                "LALIGA": 1,
-                "EPL": 2,
-                "COPA": 3,
-                "FA": 4,
-                "EFL": 5,
+                "WCQ": 1,
+                "LALIGA": 2,
+                "EPL": 3,
+                "COPA": 4,
+                "FA": 5,
+                "EFL": 6,
             }
             comp_score = comp_priority.get(m.competition, 99)
             return (r_score, comp_score)


### PR DESCRIPTION
## Summary
- Add generated standalone profiles for 10 Athletic Club players
- Keep generated profile pages available in the repo alongside the deployed Hosting output
- Includes existing WCQ support commit already present on this branch

## Verification
- Generated 10 standalone profile HTML files
- Pushed Athletic Club CSV updates to GCS
- Deployed with ./scripts/safe_deploy.sh
- Verified public standalone fragments and report modal/data-player-profile-url/fetch/badge wiring